### PR TITLE
Multi-Day Trip Functionality

### DIFF
--- a/src/components/add-day-dialog.js
+++ b/src/components/add-day-dialog.js
@@ -1,5 +1,20 @@
 import React, { useState, useEffect } from "react";
-import { Dialog, DialogActions, DialogContent, DialogTitle, Button, TextField, FormControl, InputLabel, Select, MenuItem, Checkbox, FormControlLabel, Stack, Chip } from "@mui/material";
+import {
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Button,
+    TextField,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Select,
+    Checkbox,
+    FormControlLabel,
+    Stack,
+    Chip
+} from "@mui/material";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
@@ -27,7 +42,7 @@ const AddDayDialog = ({ open, onClose, onSave, startingLocation, previousDayDate
     };
 
     return (
-        <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
             <DialogTitle>Add New Day</DialogTitle>
             <DialogContent>
                 <LocalizationProvider dateAdapter={AdapterDayjs}>
@@ -53,30 +68,31 @@ const AddDayDialog = ({ open, onClose, onSave, startingLocation, previousDayDate
                         label="Mode of Transportation"
                         value={transportMode}
                         onChange={(event) => setTransportMode(event.target.value)}>
-                        <MenuItem value="driving">Driving</MenuItem>
-                        <MenuItem value="transit">Transit</MenuItem>
-                        <MenuItem value="bicycling">Bicycling</MenuItem>
-                        <MenuItem value="walking">Walking</MenuItem>
+                        <MenuItem value="DRIVING">Driving</MenuItem>
+                        <MenuItem value="TRANSIT">Transit</MenuItem>
+                        <MenuItem value="BICYCLING">Bicycling</MenuItem>
+                        <MenuItem value="WALKING">Walking</MenuItem>
                     </Select>
                 </FormControl>
-                <TextField
-                    label="Tags"
-                    value={tagInput}
-                    onChange={(e) => setTagInput(e.target.value)}
-                    fullWidth
-                    margin="normal"
-                />
-                <Button
-                    variant="outlined"
-                    onClick={() => {
-                        if (tagInput.length > 0 && !tags.includes(tagInput)) {
-                            setTags([...tags, tagInput]);
-                        }
-                    }}
-                    fullWidth
-                    margin="normal">
-                    Add Tag
-                </Button>
+                <Stack direction="row" spacing={2} alignItems="center" margin="normal">
+                    <TextField
+                        label="Tags"
+                        value={tagInput}
+                        onChange={(e) => setTagInput(e.target.value)}
+                        sx={{ flex: 1 }} // Set the width to take up available space
+                    />
+                    <Button
+                        variant="outlined"
+                        onClick={() => {
+                            if (tagInput.length > 0 && !tags.includes(tagInput)) {
+                                setTags([...tags, tagInput]);
+                                setTagInput(''); // Clear the input after adding the tag
+                            }
+                        }}
+                        sx={{ height: '56px', flexShrink: 0 }}>
+                        Add Tag
+                    </Button>
+                </Stack>
                 {tags.length > 0 && (
                     <Stack direction="row" spacing={2} sx={{ flexWrap: "wrap" }} useFlexGap margin="normal">
                         {tags.map((tag, index) => (
@@ -98,7 +114,7 @@ const AddDayDialog = ({ open, onClose, onSave, startingLocation, previousDayDate
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClose}>Cancel</Button>
-                <Button onClick={handleSave}>Save</Button>
+                <Button onClick={handleSave}>Add Day</Button>
             </DialogActions>
         </Dialog>
     );

--- a/src/components/add-day-dialog.js
+++ b/src/components/add-day-dialog.js
@@ -1,0 +1,107 @@
+import React, { useState, useEffect } from "react";
+import { Dialog, DialogActions, DialogContent, DialogTitle, Button, TextField, FormControl, InputLabel, Select, MenuItem, Checkbox, FormControlLabel, Stack, Chip } from "@mui/material";
+import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import dayjs from "dayjs";
+
+const AddDayDialog = ({ open, onClose, onSave, startingLocation, previousDayDate }) => {
+    const [dateObject, setDateObject] = useState(dayjs(previousDayDate).add(1, 'day'));
+    const [tagInput, setTagInput] = useState("");
+    const [tags, setTags] = useState([]);
+    const [transportMode, setTransportMode] = useState("");
+    const [usePrevStops, setUsePrevStops] = useState(false);
+
+    useEffect(() => {
+        setDateObject(dayjs(previousDayDate).add(1, 'day'));
+    }, [previousDayDate]);
+
+    const handleSave = () => {
+        const newDay = {
+            date: dateObject,
+            tags,
+            transportMode,
+            usePrevStops
+        };
+        console.log("usePrevStops in AddDayDialog:", usePrevStops); // Debugging line
+        onSave(newDay);
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+            <DialogTitle>Add New Day</DialogTitle>
+            <DialogContent>
+                <LocalizationProvider dateAdapter={AdapterDayjs}>
+                    <DatePicker
+                        label="Starting Date"
+                        value={dateObject}
+                        onChange={(newDate) => setDateObject(newDate)}
+                        disabled
+                        fullWidth
+                    />
+                </LocalizationProvider>
+                <TextField
+                    label="Starting Location"
+                    value={startingLocation}
+                    fullWidth
+                    disabled
+                    margin="normal"
+                />
+                <FormControl fullWidth margin="normal">
+                    <InputLabel id="transportLabel">Mode of Transportation</InputLabel>
+                    <Select
+                        labelId="transportLabel"
+                        label="Mode of Transportation"
+                        value={transportMode}
+                        onChange={(event) => setTransportMode(event.target.value)}>
+                        <MenuItem value="driving">Driving</MenuItem>
+                        <MenuItem value="transit">Transit</MenuItem>
+                        <MenuItem value="bicycling">Bicycling</MenuItem>
+                        <MenuItem value="walking">Walking</MenuItem>
+                    </Select>
+                </FormControl>
+                <TextField
+                    label="Tags"
+                    value={tagInput}
+                    onChange={(e) => setTagInput(e.target.value)}
+                    fullWidth
+                    margin="normal"
+                />
+                <Button
+                    variant="outlined"
+                    onClick={() => {
+                        if (tagInput.length > 0 && !tags.includes(tagInput)) {
+                            setTags([...tags, tagInput]);
+                        }
+                    }}
+                    fullWidth
+                    margin="normal">
+                    Add Tag
+                </Button>
+                {tags.length > 0 && (
+                    <Stack direction="row" spacing={2} sx={{ flexWrap: "wrap" }} useFlexGap margin="normal">
+                        {tags.map((tag, index) => (
+                            <Chip
+                                label={tag}
+                                key={index}
+                                onDelete={() => setTags(tags.filter((tagStr) => tagStr !== tag))}
+                            />
+                        ))}
+                    </Stack>
+                )}
+                <FormControlLabel
+                    control={
+                        <Checkbox checked={usePrevStops} onChange={(e) => setUsePrevStops(e.target.checked)} />
+                    }
+                    label="Use Previous Stops"
+                    margin="normal"
+                />
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>Cancel</Button>
+                <Button onClick={handleSave}>Save</Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default AddDayDialog;

--- a/src/components/trip.js
+++ b/src/components/trip.js
@@ -1,19 +1,19 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { GoogleMap, LoadScript, Polyline, Marker } from "@react-google-maps/api";
-import { Box, Typography, Card, CardContent, TextField, FormControl } from "@mui/material";
+import { Box, Typography, Card, CardContent, TextField, FormControl, Button, MenuItem, Select } from "@mui/material";
+import AddDayDialog from "./add-day-dialog"; // Import the AddDayDialog component
+import dayjs from "dayjs";
 
-// Load the necessary libraries for Google Maps
 const libraries = ["places", "marker"];
 const data = JSON.parse(window.sessionStorage.getItem("data"));
 
 const Trip = () => {
     const [mapCenter, setMapCenter] = useState({ lat: -34.397, lng: 150.644 });
-    const [routePath, setRoutePath] = useState([]);
-    const [markers, setMarkers] = useState([]);
-    const [travelTimes, setTravelTimes] = useState([]); // State to store travel times
+    const [days, setDays] = useState([{ markers: [], routePath: [], travelTimes: [], durations: {}, notes: {} }]);
+    const [selectedDayIndex, setSelectedDayIndex] = useState(0);
     const [selectedNode, setSelectedNode] = useState(null);
-    const [notes, setNotes] = useState(""); // State to store notes
-    const [durations, setDurations] = useState({}); // State to store durations
+    const [isDialogOpen, setIsDialogOpen] = useState(false);
+    const polylineRef = useRef(null);
 
     const handleLoad = () => {
         const loadGoogleMaps = async () => {
@@ -35,137 +35,139 @@ const Trip = () => {
                 lng: data.startingLocation.longitude || 0
             };
             setMapCenter(location); // Center the map on the selected location
-            setMarkers([{
-                position: location,
-                label: "1",
-                name: data.startingLocation.name,
-                info: data.startingLocation.address,
-                rating: data.startingLocation.user_ratings_total || "N/A",
-            }]);
-            fetchNearbyPlaces(location); // Fetch nearby places based on the selected location
+            setDays([{ markers: [{ position: location, label: "1", name: data.startingLocation.name, info: data.startingLocation.address, rating: data.startingLocation.user_ratings_total || "N/A" }], routePath: [], travelTimes: [], durations: {}, notes: {} }]);
+            fetchNearbyPlaces(location, 0, false); // Fetch nearby places for the first day
         } else {
             console.error("Couldn't load data from session storage!");
         }
     };
 
-    // Fetch nearby places using the Google Places API
-    const fetchNearbyPlaces = (location) => {
+    const fetchNearbyPlaces = (location, dayIndex, usePrevStops) => {
         if (!window.google || !window.google.maps || !window.google.maps.places) {
             console.error("Google Maps Places API is not loaded.");
             return;
         }
 
-        const service = new window.google.maps.places.PlacesService(document.createElement("div")); // Create a new PlacesService instance
+        const service = new window.google.maps.places.PlacesService(document.createElement("div"));
         const request = {
             location,
-            radius: "5000", // Search within a 5000-meter radius
-            type: ["restaurant"], // This is probably how we will filter out the places we want to visit by trip preferences
-            rankBy: window.google.maps.places.RankBy.PROMINENCE // Rank results by prominence
+            radius: "5000",
+            type: ["restaurant"],
+            rankBy: window.google.maps.places.RankBy.PROMINENCE
         };
 
-        service.nearbySearch(request, (results, status) => {
+        const handleResults = (results, status) => {
             if (status === window.google.maps.places.PlacesServiceStatus.OK) {
-                // Sort results by rating and take the top 3
-                const sortedResults = results.sort((a, b) => b.rating - a.rating).slice(0, 3);
+                let sortedResults = results.sort((a, b) => b.rating - a.rating);
 
-                // Set markers for the nearby places
-                const newMarkers = sortedResults.map((place, index) => ({
+                if (!usePrevStops) {
+                    const usedPlaces = new Set(days.flatMap(day => day.markers.map(marker => marker.name)));
+                    sortedResults = sortedResults.filter(place => !usedPlaces.has(place.name));
+                }
+
+                const newMarkers = sortedResults.slice(0, 3).map((place, index) => ({
                     position: { lat: place.geometry.location.lat(), lng: place.geometry.location.lng() },
-                    label: `${index + 2}`, // Start numbering from 2 since 1 is the initial location
-                    name: place.name, // Set the name of the place
-                    info: place.vicinity, // Set the info of the place
-                    rating: place.user_ratings_total, // Set the prominence (user ratings total) of the place
-                    duration: { hours: 2, minutes: 0 } // Default duration
+                    label: `${index + 2}`,
+                    name: place.name,
+                    info: place.vicinity,
+                    rating: place.user_ratings_total,
+                    duration: { hours: 2, minutes: 0 }
                 }));
-                setMarkers((prevMarkers) => [...prevMarkers, ...newMarkers]); // Add new markers to the existing ones
 
-                // Set default durations for the new markers
-                const newDurations = sortedResults.reduce((acc, place) => {
-                    acc[place.name] = { hours: 2, minutes: 0 };
-                    return acc;
-                }, {});
-                setDurations((prevDurations) => ({ ...prevDurations, ...newDurations }));
+                setDays((prevDays) => {
+                    const updatedDays = [...prevDays];
+                    updatedDays[dayIndex].markers = [updatedDays[dayIndex].markers[0], ...newMarkers];
+                    return updatedDays;
+                });
 
-                calculateRoute(location, sortedResults); // Calculate the route including these places
+                if (newMarkers.length > 0) {
+                    calculateRoute(location, newMarkers, dayIndex);
+                } else {
+                    console.warn("No new places found for the given criteria.");
+                }
             } else {
                 console.error("PlacesServiceStatus not OK:", status);
             }
-        });
+        };
+
+        service.nearbySearch(request, handleResults);
     };
 
-    // Calculate the route between the selected location and the nearby places
-    const calculateRoute = (origin, places) => {
-        const directionsService = new window.google.maps.DirectionsService(); // Create a new DirectionsService instance
+    const calculateRoute = (origin, places, dayIndex) => {
+        const directionsService = new window.google.maps.DirectionsService();
         const waypoints = places.map((place) => ({
-            location: { lat: place.geometry.location.lat(), lng: place.geometry.location.lng() }, // Convert place geometry to lat/lng
-            stopover: true // Indicate that these are stopover points
+            location: { lat: place.position.lat, lng: place.position.lng },
+            stopover: true
         }));
+
+        if (waypoints.length === 0) {
+            console.warn("No waypoints found for the route.");
+            return;
+        }
 
         const request = {
             origin,
-            destination: waypoints[waypoints.length - 1].location, // Set the last waypoint as the destination
+            destination: waypoints[waypoints.length - 1].location,
             waypoints,
-            travelMode: window.google.maps.TravelMode.DRIVING // Set the travel mode to driving
+            travelMode: window.google.maps.TravelMode.DRIVING
         };
 
-        directionsService
-            .route(request, (result, status) => {
-                if (status === window.google.maps.DirectionsStatus.OK) {
-                    // Convert the route to an array of lat/lng points
-                    const route = result.routes[0].overview_path.map((point) => ({
-                        lat: point.lat(),
-                        lng: point.lng()
-                    }));
-                    setRoutePath(route); // Update state with the route path
-
-                    // Extract travel times from the directions result
-                    const times = result.routes[0].legs.map((leg) => leg.duration.text);
-                    setTravelTimes(times); // Update state with the travel times
-                }
-            })
-            .catch(() => console.error("Route Request Failed!"));
+        directionsService.route(request, (result, status) => {
+            if (status === window.google.maps.DirectionsStatus.OK) {
+                const route = result.routes[0].overview_path.map((point) => ({
+                    lat: point.lat(),
+                    lng: point.lng()
+                }));
+                const times = result.routes[0].legs.map((leg) => leg.duration.text);
+                setDays((prevDays) => {
+                    const updatedDays = [...prevDays];
+                    updatedDays[dayIndex].routePath = route;
+                    updatedDays[dayIndex].travelTimes = times;
+                    return updatedDays;
+                });
+            } else {
+                console.error("Route calculation failed:", status);
+            }
+        });
     };
 
     const handleNotesChange = (e) => {
         const { value } = e.target;
-        setNotes((prevNotes) => ({
-            ...prevNotes,
-            [selectedNode.name]: value
-        }));
+        setDays((prevDays) => {
+            const updatedDays = [...prevDays];
+            updatedDays[selectedDayIndex].notes[selectedNode.name] = value;
+            return updatedDays;
+        });
     };
 
     const handleHoursChange = (e) => {
         const value = Math.max(0, e.target.value);
-        setDurations((prevDurations) => ({
-            ...prevDurations,
-            [selectedNode.name]: {
-                ...prevDurations[selectedNode.name],
-                hours: value
-            }
-        }));
+        setDays((prevDays) => {
+            const updatedDays = [...prevDays];
+            updatedDays[selectedDayIndex].durations[selectedNode.name].hours = value;
+            return updatedDays;
+        });
     };
 
     const handleMinutesChange = (e) => {
         const value = Math.max(0, e.target.value);
-        setDurations((prevDurations) => ({
-            ...prevDurations,
-            [selectedNode.name]: {
-                ...prevDurations[selectedNode.name],
-                minutes: value
-            }
-        }));
+        setDays((prevDays) => {
+            const updatedDays = [...prevDays];
+            updatedDays[selectedDayIndex].durations[selectedNode.name].minutes = value;
+            return updatedDays;
+        });
     };
 
     const calculateTotalTripDuration = () => {
         let totalMinutes = 0;
-    
-        // Add durations spent at each location, excluding the initial destination
-        Object.entries(durations).forEach(([name, duration], index) => {
+        const durations = days[selectedDayIndex].durations;
+        const travelTimes = days[selectedDayIndex].travelTimes;
+
+        Object.entries(durations).forEach(([name, duration]) => {
             const locationMinutes = (parseInt(duration.hours) || 0) * 60 + (parseInt(duration.minutes) || 0);
             totalMinutes += locationMinutes;
         });
-    
-        // Add travel times between locations
+
         travelTimes.forEach(time => {
             const [value, unit] = time.split(' ');
             let travelMinutes = 0;
@@ -176,163 +178,223 @@ const Trip = () => {
             }
             totalMinutes += travelMinutes;
         });
-    
+
         const hours = Math.floor(totalMinutes / 60);
         const minutes = totalMinutes % 60;
         return `${hours} hours and ${minutes} minutes`;
     };
 
-    // noinspection JSValidateTypes
+    const handleAddDay = () => {
+        setIsDialogOpen(true);
+    };
+
+    const handleSaveDay = (newDay) => {
+        const newDayIndex = days.length;
+        const newDayData = {
+            markers: [{ position: mapCenter, label: "1", name: data.startingLocation.name, info: data.startingLocation.address, rating: data.startingLocation.user_ratings_total || "N/A" }],
+            routePath: [],
+            travelTimes: [],
+            durations: {},
+            notes: {}
+        };
+
+        fetchNearbyPlaces(mapCenter, newDayIndex, newDay.usePrevStops);
+
+        setDays((prevDays) => [...prevDays, newDayData]);
+        setSelectedDayIndex(newDayIndex);
+        setIsDialogOpen(false);
+    };
+
+    useEffect(() => {
+        // Remove the existing polyline from the map when switching days
+        if (polylineRef.current) {
+            polylineRef.current.setMap(null);
+        }
+    }, [selectedDayIndex]);
+
     return (
         <LoadScript
             googleMapsApiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}
             libraries={libraries}
             onLoad={handleLoad}>
-            <Box display="flex" height="80vh" alignItems="center" justifyContent="center">
-                <Box
-                    width="25%"
-                    padding="10px"
-                    display="flex"
-                    flexDirection="column"
-                    alignItems="center"
-                    overflow="auto"
-                    mr={4}>
-                    {markers.map((marker, index) => (
-                        <Box
-                            key={index}
-                            display="flex"
-                            flexDirection="column"
-                            alignItems="center"
-                            mb={2}
-                            onClick={() => setSelectedNode(selectedNode?.name === marker.name ? null : marker)}
-                            sx={{ cursor: "pointer" }}>
-                            <Box
-                                display="flex"
-                                flexDirection="column"
-                                alignItems="center"
-                                justifyContent="center"
-                                bgcolor={selectedNode?.name === marker.name ? "#4caf50" : "primary.main"}
-                                color="white"
-                                borderRadius="16px"
-                                padding="10px"
-                                width="100%"
-                                minWidth="250px"
-                                minHeight="50px"
-                                textAlign="center"
-                                boxShadow={3}>
-                                <Typography variant="h6">{marker.name}</Typography>
-                            </Box>
-                            {index < markers.length - 1 && (
-                                <Box display="flex" alignItems="center">
-                                    <Box
-                                        position="relative"
-                                        width="2px"
-                                        height="65px"
-                                        bgcolor="#686879"
-                                        mb={-2}
-                                        sx={{
-                                            "&::after": {
-                                                content: '""',
-                                                position: "absolute",
-                                                bottom: 0,
-                                                left: "50%",
-                                                transform: "translateX(-50%)",
-                                                borderLeft: "5px solid transparent",
-                                                borderRight: "5px solid transparent",
-                                                borderTop: "10px solid #686879"
-                                            }
-                                        }}
-                                    />
-                                    <Typography variant="body2" ml={2} color="#686879">
-                                        {travelTimes[index]}
-                                    </Typography>
-                                </Box>
-                            )}
-                        </Box>
-                    ))}
-                    <Typography variant="body1" mt={2} align="center" color="#686879">
-                        Total Time: {calculateTotalTripDuration()}
-                    </Typography>
-                </Box>
-                <Box flex={1} display="flex" flexDirection="column" alignItems="center" width="75%">
-                    <GoogleMap
-                        id="map"
-                        mapContainerStyle={{ height: "400px", width: "100%" }}
-                        zoom={14}
-                        center={mapCenter}
-                        options={{ mapId: "651e26fab50abd83" }}>
-                        {markers.map((marker, index) => (
-                            <Marker
-                                key={index}
-                                position={marker.position}
-                                label={marker.label}
-                                onClick={() => setSelectedNode(selectedNode?.name === marker.name ? null : marker)}
-                            />
+            <Box display="flex" flexDirection="column" height="80vh" alignItems="center" justifyContent="center">
+                <Box display="flex" alignItems="center" justifyContent="center" mb={2}>
+                    <Select
+                        value={selectedDayIndex}
+                        onChange={(e) => setSelectedDayIndex(e.target.value)}
+                        displayEmpty
+                        inputProps={{ 'aria-label': 'Select Day' }}
+                        sx={{ mr: 2 }}>
+                        {days.map((_, index) => (
+                            <MenuItem key={index} value={index}>
+                                Day {index + 1}
+                            </MenuItem>
                         ))}
-                        {routePath.length > 0 && (
-                            <Polyline
-                                path={routePath} // Set the path of the polyline
-                                options={{
-                                    strokeColor: "#DD0066",
-                                    strokeOpacity: 0.75,
-                                    strokeWeight: 6
-                                }}
-                            />
-                        )}
-                    </GoogleMap>
-                    {selectedNode && (
-                        <Card mt={2} p={2} sx={{ minHeight: '400px', width: '100%', mt: 2 }}>
-                            <CardContent>
-                                <Typography variant="h6" gutterBottom>
-                                    {selectedNode.name}
-                                </Typography>
-                                <Typography variant="body1" gutterBottom sx={{ mt: -0.75, mb: 2, color: 'gray' }}>
-                                    {selectedNode.info}
-                                </Typography>
-                                {selectedNode.label !== "1" && (
-                                    <>
-                                        <FormControl fullWidth variant="outlined" margin="normal">
-                                            <Typography variant="body1">
-                                                Duration:
+                    </Select>
+                    <Button variant="contained" color="primary" onClick={handleAddDay}>
+                        Add New Day
+                    </Button>
+                </Box>
+                <Box display="flex" height="100%" width="100%" alignItems="center" justifyContent="center">
+                    <Box
+                        width="25%"
+                        padding="10px"
+                        display="flex"
+                        flexDirection="column"
+                        alignItems="center"
+                        overflow="auto"
+                        mr={4}>
+                        {days[selectedDayIndex].markers.map((marker, index) => (
+                            marker && (
+                                <Box
+                                    key={index}
+                                    display="flex"
+                                    flexDirection="column"
+                                    alignItems="center"
+                                    mb={2}
+                                    onClick={() => setSelectedNode(selectedNode?.name === marker.name ? null : marker)}
+                                    sx={{ cursor: "pointer" }}>
+                                    <Box
+                                        display="flex"
+                                        flexDirection="column"
+                                        alignItems="center"
+                                        justifyContent="center"
+                                        bgcolor={selectedNode?.name === marker.name ? "#4caf50" : "primary.main"}
+                                        color="white"
+                                        borderRadius="16px"
+                                        padding="10px"
+                                        width="100%"
+                                        minWidth="250px"
+                                        minHeight="50px"
+                                        textAlign="center"
+                                        boxShadow={3}>
+                                        <Typography variant="h6">{marker.name}</Typography>
+                                    </Box>
+                                    {index < days[selectedDayIndex].markers.length - 1 && (
+                                        <Box display="flex" alignItems="center">
+                                            <Box
+                                                position="relative"
+                                                width="2px"
+                                                height="65px"
+                                                bgcolor="#686879"
+                                                mb={-2}
+                                                sx={{
+                                                    "&::after": {
+                                                        content: '""',
+                                                        position: "absolute",
+                                                        bottom: 0,
+                                                        left: "50%",
+                                                        transform: "translateX(-50%)",
+                                                        borderLeft: "5px solid transparent",
+                                                        borderRight: "5px solid transparent",
+                                                        borderTop: "10px solid #686879"
+                                                    }
+                                                }}
+                                            />
+                                            <Typography variant="body2" ml={2} color="#686879">
+                                                {days[selectedDayIndex].travelTimes[index]}
                                             </Typography>
-                                            <Box display="flex">
-                                                <TextField
-                                                    label="Hours"
-                                                    type="number"
-                                                    variant="outlined"
-                                                    margin="normal"
-                                                    value={durations[selectedNode.name]?.hours}
-                                                    onChange={handleHoursChange}
-                                                    style={{ marginRight: '10px' }}
-                                                    slotProps={{ htmlInput: { min: 0 } }}
-                                                />
-                                                <TextField
-                                                    label="Minutes"
-                                                    type="number"
-                                                    variant="outlined"
-                                                    margin="normal"
-                                                    value={durations[selectedNode.name]?.minutes}
-                                                    onChange={handleMinutesChange}
-                                                    slotProps={{ htmlInput: { min: 0 } }}
-                                                />
-                                            </Box>
-                                        </FormControl>
-                                    </>
-                                )}
-                                <TextField
-                                    label="Enter Notes"
-                                    multiline
-                                    rows={4}
-                                    variant="outlined"
-                                    fullWidth
-                                    value={notes[selectedNode.name] || ""}
-                                    onChange={handleNotesChange}
+                                        </Box>
+                                    )}
+                                </Box>
+                            )
+                        ))}
+                        <Typography variant="body1" mt={2} align="center" color="#686879">
+                            Total Time: {calculateTotalTripDuration()}
+                        </Typography>
+                    </Box>
+                    <Box flex={1} display="flex" flexDirection="column" alignItems="center" width="75%">
+                        <GoogleMap
+                            id="map"
+                            mapContainerStyle={{ height: "400px", width: "100%" }}
+                            zoom={14}
+                            center={mapCenter}
+                            options={{ mapId: "651e26fab50abd83" }}>
+                            {days[selectedDayIndex].markers.map((marker, index) => (
+                                marker && (
+                                    <Marker
+                                        key={index}
+                                        position={marker.position}
+                                        label={marker.label}
+                                        onClick={() => setSelectedNode(selectedNode?.name === marker.name ? null : marker)}
+                                    />
+                                )
+                            ))}
+                            {days[selectedDayIndex].routePath.length > 0 && (
+                                <Polyline
+                                    path={days[selectedDayIndex].routePath}
+                                    options={{
+                                        strokeColor: "#DD0066",
+                                        strokeOpacity: 0.75,
+                                        strokeWeight: 6
+                                    }}
+                                    onLoad={(polyline) => {
+                                        polylineRef.current = polyline;
+                                    }}
                                 />
-                            </CardContent>
-                        </Card>
-                    )}
+                            )}
+                        </GoogleMap>
+                        {selectedNode && (
+                            <Card mt={2} p={2} sx={{ minHeight: '400px', width: '100%', mt: 2 }}>
+                                <CardContent>
+                                    <Typography variant="h6" gutterBottom>
+                                        {selectedNode.name}
+                                    </Typography>
+                                    <Typography variant="body1" gutterBottom sx={{ mt: -0.75, mb: 2, color: 'gray' }}>
+                                        {selectedNode.info}
+                                    </Typography>
+                                    {selectedNode.label !== "1" && (
+                                        <>
+                                            <FormControl fullWidth variant="outlined" margin="normal">
+                                                <Typography variant="body1">
+                                                    Duration:
+                                                </Typography>
+                                                <Box display="flex">
+                                                    <TextField
+                                                        label="Hours"
+                                                        type="number"
+                                                        variant="outlined"
+                                                        margin="normal"
+                                                        value={days[selectedDayIndex].durations[selectedNode.name]?.hours}
+                                                        onChange={handleHoursChange}
+                                                        style={{ marginRight: '10px' }}
+                                                        slotProps={{ htmlInput: { min: 0 } }}
+                                                    />
+                                                    <TextField
+                                                        label="Minutes"
+                                                        type="number"
+                                                        variant="outlined"
+                                                        margin="normal"
+                                                        value={days[selectedDayIndex].durations[selectedNode.name]?.minutes}
+                                                        onChange={handleMinutesChange}
+                                                        slotProps={{ htmlInput: { min: 0 } }}
+                                                    />
+                                                </Box>
+                                            </FormControl>
+                                        </>
+                                    )}
+                                    <TextField
+                                        label="Enter Notes"
+                                        multiline
+                                        rows={4}
+                                        variant="outlined"
+                                        fullWidth
+                                        value={days[selectedDayIndex].notes[selectedNode.name] || ""}
+                                        onChange={handleNotesChange}
+                                    />
+                                </CardContent>
+                            </Card>
+                        )}
+                    </Box>
                 </Box>
             </Box>
+            <AddDayDialog
+                open={isDialogOpen}
+                onClose={() => setIsDialogOpen(false)}
+                onSave={handleSaveDay}
+                startingLocation={data.startingLocation.name}
+                previousDayDate={dayjs().format('YYYY-MM-DD')}
+            />
         </LoadScript>
     );
 };

--- a/src/components/trip.js
+++ b/src/components/trip.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { GoogleMap, LoadScript, Polyline, Marker } from "@react-google-maps/api";
-import { Box, Typography, Card, CardContent, TextField, FormControl, Button, MenuItem, Select } from "@mui/material";
+import { Box, Typography, Card, CardContent, TextField, FormControl, Button } from "@mui/material";
 import AddDayDialog from "./add-day-dialog"; // Import the AddDayDialog component
 import dayjs from "dayjs";
 
@@ -219,21 +219,58 @@ const Trip = () => {
             onLoad={handleLoad}>
             <Box display="flex" flexDirection="column" height="80vh" alignItems="center" justifyContent="center">
                 <Box display="flex" alignItems="center" justifyContent="center" mb={2}>
-                    <Select
-                        value={selectedDayIndex}
-                        onChange={(e) => setSelectedDayIndex(e.target.value)}
-                        displayEmpty
-                        inputProps={{ 'aria-label': 'Select Day' }}
-                        sx={{ mr: 2 }}>
+                    <Box display="flex" alignItems="center">
                         {days.map((_, index) => (
-                            <MenuItem key={index} value={index}>
-                                Day {index + 1}
-                            </MenuItem>
+                            <React.Fragment key={index}>
+                                <Box
+                                    onClick={() => setSelectedDayIndex(index)}
+                                    sx={{
+                                        width: 40,
+                                        height: 40,
+                                        borderRadius: "50%",
+                                        backgroundColor: selectedDayIndex === index ? "#4caf50" : "#1976d2",
+                                        display: "flex",
+                                        alignItems: "center",
+                                        justifyContent: "center",
+                                        color: "white",
+                                        cursor: "pointer",
+                                    }}>
+                                    {index + 1}
+                                </Box>
+                                {index < days.length - 1 && (
+                                    <Box
+                                        sx={{
+                                            width: 35,
+                                            height: 2,
+                                            backgroundColor: "#686879"
+                                        }}
+                                    />
+                                )}
+                            </React.Fragment>
                         ))}
-                    </Select>
-                    <Button variant="contained" color="primary" onClick={handleAddDay}>
-                        Add New Day
-                    </Button>
+                            <Box
+                                sx={{
+                                    width: 35,
+                                    height: 2,
+                                    backgroundColor: "#686879"
+                                }}
+                            />
+                            <Box
+                            onClick={handleAddDay}
+                            sx={{
+                                width: 40,
+                                height: 40,
+                                borderRadius: "50%",
+                                backgroundColor: "#777777",
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                color: "white",
+                                cursor: "pointer"
+                            }}>
+                            +
+                        </Box>
+                    </Box>
                 </Box>
                 <Box display="flex" height="100%" width="100%" alignItems="center" justifyContent="center">
                     <Box

--- a/src/components/trip.js
+++ b/src/components/trip.js
@@ -77,6 +77,13 @@ const Trip = () => {
                 setDays((prevDays) => {
                     const updatedDays = [...prevDays];
                     updatedDays[dayIndex].markers = [updatedDays[dayIndex].markers[0], ...newMarkers];
+                    updatedDays[dayIndex].durations = {
+                        ...updatedDays[dayIndex].durations,
+                        ...newMarkers.reduce((acc, marker) => {
+                            acc[marker.name] = { hours: 2, minutes: 0 };
+                            return acc;
+                        }, {})
+                    };
                     return updatedDays;
                 });
 
@@ -144,6 +151,9 @@ const Trip = () => {
         const value = Math.max(0, e.target.value);
         setDays((prevDays) => {
             const updatedDays = [...prevDays];
+            if (!updatedDays[selectedDayIndex].durations[selectedNode.name]) {
+                updatedDays[selectedDayIndex].durations[selectedNode.name] = { hours: 0, minutes: 0 };
+            }
             updatedDays[selectedDayIndex].durations[selectedNode.name].hours = value;
             return updatedDays;
         });
@@ -153,6 +163,9 @@ const Trip = () => {
         const value = Math.max(0, e.target.value);
         setDays((prevDays) => {
             const updatedDays = [...prevDays];
+            if (!updatedDays[selectedDayIndex].durations[selectedNode.name]) {
+                updatedDays[selectedDayIndex].durations[selectedNode.name] = { hours: 0, minutes: 0 };
+            }
             updatedDays[selectedDayIndex].durations[selectedNode.name].minutes = value;
             return updatedDays;
         });

--- a/src/components/trip.js
+++ b/src/components/trip.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { GoogleMap, LoadScript, Polyline, Marker } from "@react-google-maps/api";
-import { Box, Typography, Card, CardContent, TextField, FormControl, Button } from "@mui/material";
+import { Box, Typography, Card, CardContent, TextField, FormControl } from "@mui/material";
 import AddDayDialog from "./add-day-dialog"; // Import the AddDayDialog component
 import dayjs from "dayjs";
 


### PR DESCRIPTION
This will add a timeline of days to the center top position of the screen, which has an option to add another day to that list.

Trying to add a day will bring up a popup which asks for similar information to what is used on the `create-trip` page, except setting date and initial location is locked, with their values being a day after the previous day, and the same location as the first day respectively.

If you set the checkbox to use previous stops, the day will generate the exact same thing as the first day, further down the line we may want to adjust that. If the checkbox is not set (the default), the new day generated will have all new suggested stops.

You may switch between days freely, nodes information is kept when you switch between them even in browser, so if you set a comment, switch day, and switch back the same node will have the same comment.